### PR TITLE
Don't source files by default

### DIFF
--- a/R/makeChartConfig.R
+++ b/R/makeChartConfig.R
@@ -27,7 +27,7 @@
 #' }
 #' @export
 
-makeChartConfig <- function(dirs, packages="safetyCharts", packageLocation="config", sourceFiles=TRUE){
+makeChartConfig <- function(dirs, packages="safetyCharts", packageLocation="config", sourceFiles=FALSE){
     if(missing(dirs)) dirs<-NULL
 
     # add local package installation to dirs if specified in packages

--- a/man/makeChartConfig.Rd
+++ b/man/makeChartConfig.Rd
@@ -8,7 +8,7 @@ makeChartConfig(
   dirs,
   packages = "safetyCharts",
   packageLocation = "config",
-  sourceFiles = TRUE
+  sourceFiles = FALSE
 )
 }
 \arguments{


### PR DESCRIPTION
# Overview 

Just changing default behavior so that files aren't automatically sourced. It's not needed in the standard workflow, so shouldn't effect much. 

Fix #652 

# Testing

Just confirm that standard app still works as expected. 